### PR TITLE
Remove unnecessary dep on criterion.

### DIFF
--- a/snarkl.cabal
+++ b/snarkl.cabal
@@ -91,9 +91,8 @@ library
   
   build-depends: 
     base                >=4.7,
-    containers 		>=0.5 && <0.6, 
+    containers 		>=0.5 && <0.7,
     mtl 		>=2.2 && <2.3,
-    criterion 		>=1.0 && <1.3, 
     parallel 		>=3.2 && <3.3,
     hspec               >=2.0,
     process		>=1.2,


### PR DESCRIPTION
This prevented Snårkl from being used with recent GHC.